### PR TITLE
Clang

### DIFF
--- a/src/CalcManager/Header Files/EngineStrings.h
+++ b/src/CalcManager/Header Files/EngineStrings.h
@@ -219,7 +219,7 @@
 #define SIDS_ERR_INPUT_OVERFLOW L"119"
 #define SIDS_ERR_OUTPUT_OVERFLOW L"120"
 
-__declspec(selectany) std::wstring g_sids[] = 
+DECLSPEC_SELECTANY std::wstring g_sids[] =
 {
     std::wstring(SIDS_PLUS_MINUS),
     std::wstring(SIDS_C),

--- a/src/CalcManager/Ratpack/ratpak.h
+++ b/src/CalcManager/Ratpack/ratpak.h
@@ -32,7 +32,7 @@ static constexpr uint32_t BASEX = 0x80000000; // Internal radix used in calculat
                         // overflow detection esp. in mul
 
 typedef unsigned long MANTTYPE;
-typedef unsigned __int64 TWO_MANTTYPE;
+typedef uint64_t TWO_MANTTYPE;
 
 enum eNUMOBJ_FMT {
     FMT_FLOAT,        // returns floating point, or exponential if number is too big

--- a/src/CalcManager/pch.h
+++ b/src/CalcManager/pch.h
@@ -35,4 +35,10 @@
 #include "win_data_types_cross_platform.h"
 #include "sal_cross_platform.h"
 
+#ifdef __GNUC__
+#define DECLSPEC_SELECTANY __attribute__((selectany))
+#else
+#define DECLSPEC_SELECTANY __declspec(selectany)
+#endif
+
 #endif

--- a/src/CalcManager/pch.h
+++ b/src/CalcManager/pch.h
@@ -19,7 +19,7 @@
 #include <array>
 #include <string_view>
 
-#ifdef _WIN32
+#if defined(_WIN32) && defined(_MSC_VER)
 
 #include <windows.h>
 #include <winerror.h>


### PR DESCRIPTION
## Fixes #.
This fixes build with GCC and allows the CalculatorEngine to be built on Win32 with compilers other than MSVC

### Description of the changes:
- Fix a declspec that is unknown by GCC under Linux
- Use uint64_t instead of unsigned __int64
- Include alternate headers when on Win32 without MSVC

### How changes were validated:
I can build the CalculatorEngine with GCC and Clang on Linux and also with MinGW on Win32, both as 32 and 64bit binary. I cannot check the effect on MSVC as I am stuck with VS 2015.
